### PR TITLE
Restriction of Follow Based Activities

### DIFF
--- a/Platon/backend/app/activity_stream/views.py
+++ b/Platon/backend/app/activity_stream/views.py
@@ -65,6 +65,7 @@ activity_stream_model = api.model('Activity Stream', {
     "summary": fields.String,
     "type": fields.String,
     "id": fields.Integer,
+    "totalItems": fields.Integer,
     "orderedItems": fields.List(
         fields.Nested(activity_stream_item_model)
     )
@@ -129,7 +130,9 @@ class ActivityStreamAPI(Resource):
             for following_id in followings_ids_list:
                 try:
                     # Returns activity stream items with descending timestamp value.
-                    activity_stream_items_list = ActivityStreamItem.query.filter(ActivityStreamItem.activity_actor_id == following_id).order_by(desc(ActivityStreamItem.timestamp)).all()
+                    # We have to filter out the activities that the user made to a workspace which can be identified if that activity's target type is "Group" or not.
+                    # Activities within workspaces are gathered from database not here but few lines below.
+                    activity_stream_items_list = ActivityStreamItem.query.filter((ActivityStreamItem.activity_actor_id == following_id) & (ActivityStreamItem.activity_target_type != "Group")).order_by(desc(ActivityStreamItem.timestamp)).all()
                 except:
                     # not sure to return error.
                     return make_response(jsonify({"error" : "The server is not connected to the database."}), 500)


### PR DESCRIPTION
On the left, you can see all the activity types in the Activity Stream. Meaning of abbreviations are below:
**F:** activity will be shown if that user is followed.
**W:** activity will be shown if we are contributing to the same workspace.
**ws:** workspace

This PR solves the problem 1 that is on the upper right. Problem 2 is still a problem, but it is not that urgent.

![IMG_0400](https://user-images.githubusercontent.com/39600723/105675327-042fab80-5efa-11eb-9955-0603ae26768a.JPG)
